### PR TITLE
Fix to compile with Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,14 @@ libraryDependencies ++= Seq(
   "org.scalatest"       %%  "scalatest"      % "2.2.0" % "test"
 )
 
+// Further deps depending on Scala version
+libraryDependencies <++= scalaVersion {
+  case v if v.startsWith("2.10") => Seq()
+  case v if v.startsWith("2.11") => Seq(
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
+  )
+}
+
 bintrayOrganization := Some("azavea")
 bintrayRepository := "maven"
 bintrayVcsUrl := Some("https://github.com/azavea/scala-landsat-util.git")

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "scala-landsat-util"
 version := Version.landsatUtil
-scalaVersion := "2.10.5"
-crossScalaVersions := Seq("2.11.5", "2.10.5")
+scalaVersion := "2.10.6"
+crossScalaVersions := Seq("2.11.8", "2.10.6")
 description := "API client for Developmentseed's landsat-api"
 organization := "com.azavea"
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,7 +4,7 @@ object Version {
   val landsatUtil = {
     val tag = Properties.envOrElse("TRAVIS_TAG", "")
     if(tag == "") {
-      "0.2.0" + Properties.envOrElse("LSU_VERSION_SUFFIX", "-SNAPSHOT")
+      "0.2.1" + Properties.envOrElse("LSU_VERSION_SUFFIX", "-SNAPSHOT")
     } else {
       tag
     }

--- a/sbt
+++ b/sbt
@@ -105,8 +105,8 @@ declare -r default_jvm_opts_common="-Xms512m -Xmx1536m -Xss2m $jit_opts $cms_opt
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r latest_28="2.8.2"
 declare -r latest_29="2.9.3"
-declare -r latest_210="2.10.5"
-declare -r latest_211="2.11.7"
+declare -r latest_210="2.10.6"
+declare -r latest_211="2.11.8"
 
 declare -r script_path="$(get_script_path "$BASH_SOURCE")"
 declare -r script_name="${script_path##*/}"


### PR DESCRIPTION
This library relies on `scala-parser-combinators`, which was part of the standard libary in Scala 2.10, but not 2.11. This PR adds the dependency if Scala 2.11 is detected.
