### PR TITLE
Converted Spray.io to Akka HTTP

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,13 +22,15 @@ shellPrompt := { s => Project.extract(s).currentProject.id + " > " }
 
 resolvers += "LocationTech GeoTrellis Releases" at "https://repo.locationtech.org/content/repositories/geotrellis-releases"
 
+val gtMode = if(sys.props.get("INCLUDE_GT").isDefined) "compile" else "provided"
+
 libraryDependencies ++= Seq(
   "io.spray" %% "spray-json" % "1.3.2",
-  "io.spray" %% "spray-client" % "1.3.3",
-  "io.spray" %% "spray-httpx" % "1.3.3",
-  "com.typesafe.akka" %% "akka-actor" % "2.3.16",
-  "org.locationtech.geotrellis" %% "geotrellis-vector" % Version.geotrellis % "provided",
-  "org.locationtech.geotrellis" %% "geotrellis-raster" % Version.geotrellis % "provided",
+  "com.typesafe.akka" %% "akka-actor" % Version.akka,
+  "com.typesafe.akka" %% "akka-http" % Version.akkaHttp,
+  "com.typesafe.akka" %% "akka-http-spray-json" % Version.akkaHttp,
+  "org.locationtech.geotrellis" %% "geotrellis-vector" % Version.geotrellis % gtMode,
+  "org.locationtech.geotrellis" %% "geotrellis-raster" % Version.geotrellis % gtMode,
   "org.apache.commons" % "commons-compress" % "1.12",
   "org.apache.commons" % "commons-io" % "1.3.2",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",

--- a/build.sbt
+++ b/build.sbt
@@ -20,22 +20,22 @@ pomIncludeRepository := { _ => false }
 
 shellPrompt := { s => Project.extract(s).currentProject.id + " > " }
 
-resolvers += Resolver.bintrayRepo("azavea", "geotrellis")
+resolvers += "LocationTech GeoTrellis Releases" at "https://repo.locationtech.org/content/repositories/geotrellis-releases"
 
 libraryDependencies ++= Seq(
-  "io.spray"        %% "spray-json"    % "1.3.2",
-  "io.spray"        %% "spray-client"  % "1.3.3",
-  "io.spray"        %% "spray-httpx"   % "1.3.3",
-  "com.typesafe.akka"      %% "akka-actor"   % "2.3.15",
-  "com.azavea.geotrellis"  %% "geotrellis-vector" % Version.geotrellis % "provided",
-  "com.azavea.geotrellis"  %% "geotrellis-raster" % Version.geotrellis % "provided",
-  "org.apache.commons" % "commons-compress" % "1.8",
+  "io.spray" %% "spray-json" % "1.3.2",
+  "io.spray" %% "spray-client" % "1.3.3",
+  "io.spray" %% "spray-httpx" % "1.3.3",
+  "com.typesafe.akka" %% "akka-actor" % "2.3.16",
+  "org.locationtech.geotrellis" %% "geotrellis-vector" % Version.geotrellis % "provided",
+  "org.locationtech.geotrellis" %% "geotrellis-raster" % Version.geotrellis % "provided",
+  "org.apache.commons" % "commons-compress" % "1.12",
   "org.apache.commons" % "commons-io" % "1.3.2",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.9.34",
-  "com.chuusai"   %% "shapeless" % "2.3.0",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.60",
+  "com.chuusai" %% "shapeless" % "2.3.2",
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
-  "org.scalatest"          %%  "scalatest"     % "3.0.0" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
 bintrayOrganization := Some("azavea")
@@ -44,10 +44,10 @@ bintrayVcsUrl := Some("https://github.com/azavea/scala-landsat-util.git")
 bintrayPackageLabels := Seq("scala", "landsat", "maps", "gis", "geographic", "data", "raster", "processing")
 
 initialCommands in console :=
-"""
+  """
 import com.azavea.landsatutil._
 import geotrellis.vector._
 import geotrellis.vector.io._
 import geotrellis.vector.io.json.GeoJson
 import geotrellis.raster._
-"""
+  """

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -10,6 +10,6 @@ object Version {
     }
   }
 
-  val geotrellis  = "1.0.0-39e1598"
+  val geotrellis  =  "1.0.0-RC1"
   val scala       = "2.11.8"
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -11,5 +11,7 @@ object Version {
   }
 
   val geotrellis  =  "1.0.0-RC1"
+  val akka        = "2.4.14"
+  val akkaHttp    = "10.0.0"
   val scala       = "2.11.8"
 }

--- a/src/main/scala/com/azavea/landsatutil/Examples.scala
+++ b/src/main/scala/com/azavea/landsatutil/Examples.scala
@@ -3,13 +3,16 @@ package com.azavea.landsatutil
 import geotrellis.vector._
 import geotrellis.vector.io._
 import geotrellis.vector.io.json.GeoJson
-import Json._
 
-import java.time.{ZonedDateTime, ZoneOffset}
+import java.time.{ZoneOffset, ZonedDateTime}
+
+import scala.util.{Failure, Success}
 
 object Examples {
-  def main(args: Array[String]): Unit =
+  def main(args: Array[String]): Unit = {
     phillyExample()
+    intersectExample()
+  }
 
   def phillyExample(): Unit = {
     val philly = GeoJson.fromFile[Polygon]("src/test/resources/philly.json")
@@ -47,15 +50,15 @@ object Examples {
         .execute()
 
     result match {
-      case Some(r) =>
+      case Success(r) =>
         for(image <- r.images.take(1)) {
           println(image.thumbnailUrl)
           println(image.largeThumbnail)
           println(image.smallThumbnail)
         }
         println(s"RESULT COUNT: ${r.metadata.total}")
-      case None =>
-        println("No results found!")
+      case Failure(e) =>
+        println("No results found!: " + e.getMessage)
     }
   }
 }

--- a/src/main/scala/com/azavea/landsatutil/HttpClient.scala
+++ b/src/main/scala/com/azavea/landsatutil/HttpClient.scala
@@ -6,31 +6,15 @@ import akka.http.scaladsl.model.{HttpRequest, ResponseEntity, Uri}
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import akka.stream.ActorMaterializer
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
+import scala.concurrent.Future
 
 object HttpClient {
   type SprayJsonReader[R] = Unmarshaller[ResponseEntity, R]
 
-  def get[T: SprayJsonReader](url: String)(implicit timeout: Duration): T = {
-    val system = ActorSystem(s"url_request_${java.util.UUID.randomUUID}")
-
-    try {
-      get(url, system)
-    } finally {
-      system.terminate()
-    }
-  }
-
-  def get[T: SprayJsonReader](url: String, system: ActorSystem)(implicit timeout: Duration): T = {
-    implicit val s = system
-    implicit val materializer = ActorMaterializer()
+  def get[T: SprayJsonReader](url: String)(implicit system: ActorSystem, materializer: ActorMaterializer): Future[T] = {
     import system.dispatcher
-
-    val response = Http()
+    Http()
       .singleRequest(HttpRequest(uri = Uri(url)))
       .flatMap(resp ⇒ Unmarshal(resp.entity).to[T])
-
-    Await.result(response, timeout)
   }
 }

--- a/src/main/scala/com/azavea/landsatutil/Json.scala
+++ b/src/main/scala/com/azavea/landsatutil/Json.scala
@@ -114,7 +114,7 @@ object Json {
             results.map(_.convertTo[LandsatImage])
           )
         case _ =>
-          throw new DeserializationException("QueryResult expected.")
+          throw new DeserializationException("QueryResult expected. Received: " + json)
       }
   }
 


### PR DESCRIPTION
I'm trying to keep my system consistently using Akka HTTP, and would like to use this library, so I ported the HTTP client part over. Not sure if this fits with your technology plan, and understand if you don't want this PR, but offer it up if there's interest.

I note in some comments that there are a few areas of improvement in more efficiently managing the HTTP requests, and may try to address them next.