### PR TITLE
make receivingStation optional

### DIFF
--- a/src/main/scala/com/azavea/landsatutil/Json.scala
+++ b/src/main/scala/com/azavea/landsatutil/Json.scala
@@ -39,6 +39,19 @@ object Json {
             throw DeserializationException(s"Expected field $field in image data.")
         }
 
+      def getOptionalString(field: String): Option[String] =
+        fields.get(field) match {
+          case Some(jv) =>
+            jv match {
+              case JsString(s) => Some(s)
+              case JsNull => None
+              case _ =>
+                throw DeserializationException(s"Expected field $field to be a string value.")
+            }
+          case None =>
+            throw DeserializationException(s"Expected field $field in image data.")
+        }
+
       def getNumber(field: String): BigDecimal =
         fields.get(field) match {
           case Some(jv) =>
@@ -72,7 +85,7 @@ object Json {
       val sunElevation = getNumber("sunElevation")
       val dayOrNight = getString("dayOrNight")
       val sensor = getString("sensor")
-      val receivingStation = getString("receivingStation")
+      val receivingStation = getOptionalString("receivingStation")
       val dateUpdated = getString("dateUpdated")
 
       LandsatImage(

--- a/src/main/scala/com/azavea/landsatutil/LandsatImage.scala
+++ b/src/main/scala/com/azavea/landsatutil/LandsatImage.scala
@@ -31,7 +31,7 @@ case class LandsatImage(
   sunElevation: Double,
   dayTime: Boolean,
   sensor: String,
-  receivingStation: String,
+  receivingStation: Option[String],
   dateUpdated: ZonedDateTime
 ) extends LazyLogging {
   def baseS3Path = f"L8/$path%03d/$row%03d/$sceneId"


### PR DESCRIPTION
This fixes #19. The patch makes receivingStation an optional field. An alternative would be to remove the field receivingStation as the sat-api does not seem to return any useful information in this field (it was always null for the samples we checked).