### PR TITLE
Make `receivingStation` Field Nullable, Update To 1.2.0-RC1

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -10,8 +10,8 @@ object Version {
     }
   }
 
-  val geotrellis  =  "1.0.0"
+  val geotrellis  =  "1.2.0-RC1"
   val akka        = "2.4.14"
   val akkaHttp    = "10.0.0"
-  val scala       = "2.11.8"
+  val scala       = "2.11.11"
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,7 +4,7 @@ object Version {
   val landsatUtil = {
     val tag = Properties.envOrElse("TRAVIS_TAG", "")
     if(tag == "") {
-      "1.0.0" + Properties.envOrElse("LSU_VERSION_SUFFIX", "-SNAPSHOT")
+      "1.0.1" + Properties.envOrElse("LSU_VERSION_SUFFIX", "-SNAPSHOT")
     } else {
       tag
     }

--- a/src/main/scala/com/azavea/landsatutil/Json.scala
+++ b/src/main/scala/com/azavea/landsatutil/Json.scala
@@ -39,6 +39,19 @@ object Json {
             throw DeserializationException(s"Expected field $field in image data.")
         }
 
+      def getNullableString(field: String): String =
+        fields.get(field) match {
+          case Some(jv) =>
+            jv match {
+              case JsString(s) => s
+              case JsNull => ""
+              case _ =>
+                throw DeserializationException(s"Expected field $field to be a string value or null.")
+            }
+          case None =>
+            throw DeserializationException(s"Expected field $field in image data.")
+        }
+
       def getNumber(field: String): BigDecimal =
         fields.get(field) match {
           case Some(jv) =>
@@ -72,7 +85,7 @@ object Json {
       val sunElevation = getNumber("sunElevation")
       val dayOrNight = getString("dayOrNight")
       val sensor = getString("sensor")
-      val receivingStation = getString("receivingStation")
+      val receivingStation = getNullableString("receivingStation")
       val dateUpdated = getString("dateUpdated")
 
       LandsatImage(

--- a/src/test/scala/com/azavea/landsatutil/Landsat8QuerySpec.scala
+++ b/src/test/scala/com/azavea/landsatutil/Landsat8QuerySpec.scala
@@ -24,7 +24,7 @@ class Landsat8QuerySpec extends FunSpec with Matchers {
           }
 
       images.size should be (1)
-      images.head.sceneId should be ("LC80140322015222LGN00")
+      images.head.sceneId should be ("LC80140322015222LGN01")
     }
 
     it ("should produce only well formatted queries") {


### PR DESCRIPTION
The `receivingStation` field is now (or always has been) nullable.  To verify, [visit the API link](https://api.developmentseed.org/satellites/landsat) and observe that `receivingStation` is `null` instead of s string:

```
{"meta":{"found":1098573,"name":"sat-api","license":"CC0-1.0","website":"https://api.developmentseed.org/satellites/","page":1,"limit":1},"results":[{"scene_id":"LC81392162017303LGN00","product_id":"LC08_L1GT_139216_20171030_20171030_01_RT","satellite_name":"landsat-8","cloud_coverage":-1,"date":"2017-10-30","thumbnail":"https://earthexplorer.usgs.gov/browse/landsat_8/2017/139/216/LC08_L1GT_139216_20171030_20171030_01_RT.jpg","data_geometry":{"type":"Polygon","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG:8.9:4326"}},"coordinates":[[[-122.80688,44.95859],[-120.45469,45.38569],[-121.05113,47.09534],[-123.47715,46.66339],[-122.80688,44.95859]]]},"download_links":{"usgs":"https://earthexplorer.usgs.gov/download/12864/LC81392162017303LGN00/STANDARD/EE","aws_s3":["https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_ANG.txt","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B1.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B2.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B3.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B4.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B5.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B6.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B7.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B8.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B9.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B10.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B11.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_BQA.TIF","https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_MTL.txt"],"google":["https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_ANG.txt","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B1.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B2.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B3.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B4.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B5.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B6.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B7.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B8.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B9.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B10.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_B11.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_BQA.TIF","https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_MTL.txt"]},"aws_thumbnail":"https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/LC08_L1GT_139216_20171030_20171030_01_RT_thumb_large.jpg","aws_index":"https://landsat-pds.s3.amazonaws.com/c1/L8/139/216/LC08_L1GT_139216_20171030_20171030_01_RT/index.html","google_index":"https://console.cloud.google.com/storage/browser/gcp-public-data-landsat/LC08/139/216/LC08_L1GT_139216_20171030_20171030_01_RT","browseAvailable":"Y","browseURL":"https://earthexplorer.usgs.gov/browse/landsat_8/2017/139/216/LC08_L1GT_139216_20171030_20171030_01_RT.jpg","sceneID":"LC81392162017303LGN00","LANDSAT_PRODUCT_ID":"LC08_L1GT_139216_20171030_20171030_01_RT","sensor":"OLI_TIRS","acquisitionDate":"2017-10-30","dateUpdated":"2017-10-30","path":139,"row":216,"upperLeftCornerLatitude":45.38569,"upperLeftCornerLongitude":-120.45469,"upperRightCornerLatitude":44.95859,"upperRightCornerLongitude":-122.80688,"lowerLeftCornerLatitude":47.09534,"lowerLeftCornerLongitude":-121.05113,"lowerRightCornerLatitude":46.66339,"lowerRightCornerLongitude":-123.47715,"sceneCenterLatitude":46.02966,"sceneCenterLongitude":-121.94747,"cloudCover":0,"cloudCoverFull":-1,"dayOrNight":"NIGHT","sunElevation":-48.42169449,"sunAzimuth":-49.53492727,"receivingStation":null,"sceneStartTime":"2017:303:05:45:51.4912610","sceneStopTime":"2017:303:05:46:23.2612590","imageQuality1":9,"DATA_TYPE_L1":"L1GT","cartURL":"https://earthexplorer.usgs.gov/order/process?dataset_name=LANDSAT_8_C1&ordered=LC81392162017303LGN00","ROLL_ANGLE":0,"GEOMETRIC_RMSE_MODEL":0,"GEOMETRIC_RMSE_MODEL_X":0,"GEOMETRIC_RMSE_MODEL_Y":0,"FULL_PARTIAL_SCENE":"FULL","NADIR_OFFNADIR":"NADIR","PROCESSING_SOFTWARE_VERSION":"LPGS_13.0.0","CPF_NAME":"LC08CPF_20171001_20171231_01.01","RLUT_FILE_NAME":"LC08RLUT_20150303_20431231_01_12.h5","BPF_NAME_OLI":"LO8BPF20171030042254_20171030060147.01","BPF_NAME_TIRS":"LT8BPF20171019234742_20171019235619.02","GROUND_CONTROL_POINTS_MODEL":"-1","GROUND_CONTROL_POINTS_VERSION":"4","DATE_L1_GENERATED":"2017-10-30 03:10:11","TIRS_SSM_MODEL":"PRELIMINARY","COLLECTION_NUMBER":1,"COLLECTION_CATEGORY":"RT","CLOUD_COVER_LAND":-1,"UTM_ZONE":"10","MAP_PROJECTION_L1":"UTM","DATUM":"WGS84","GRID_CELL_SIZE_REFLECTIVE":"30","GRID_CELL_SIZE_PANCHROMATIC":"15","GRID_CELL_SIZE_THERMAL":"30","ORIENTATION":"NORTH_UP","PANCHROMATIC_LINES":"15981","PANCHROMATIC_SAMPLES":"15761","REFLECTIVE_LINES":"7991","REFLECTIVE_SAMPLES":"7881","RESAMPLING_OPTION":"CUBIC_CONVOLUTION","THERMAL_LINES":"7991","THERMAL_SAMPLES":"7881"}]}
```

which was causing a deserialization error when I tried to run `make local-ingest` in `geotrellis-landsat-emr-demo`.

See also https://github.com/geotrellis/geotrellis-landsat-emr-demo/pull/27